### PR TITLE
Work with Babel >= 5.5.0

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,6 @@
+/**
+ * # Closure Eliminator
+ */
 "use strict";
 
 Object.defineProperty(exports, "__esModule", {
@@ -6,9 +9,6 @@ Object.defineProperty(exports, "__esModule", {
 
 var _createClass = (function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; })();
 
-/**
- * # Closure Eliminator
- */
 exports["default"] = build;
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
@@ -131,11 +131,11 @@ function build(babel) {
           return;
         }
 
-        if (node.type === "FunctionDeclaration") {
-          var uid = this.path.parentPath.scope.generateUidBasedOnNode(node.id);
+        if (node.type === 'FunctionDeclaration') {
+          var uid = this.path.parentPath.scope.generateUidIdentifierBasedOnNode(node.id);
           this.path.parentPath.scope.rename(node.id.name, uid.name);
           path.insertBefore([node]);
-          this.path.remove();
+          this.path.dangerouslyRemove();
         } else {
           var uid = path.scope.generateUidIdentifier("ref");
           var replacement = t.functionDeclaration(uid, node.params, normalizeFunctionBody(node.body));
@@ -153,33 +153,25 @@ function build(babel) {
   return new Transformer("closure-elimination", {
     Function: {
       enter: function enter(node, parent, scope) {
-        var _this = this;
-
         var parentScope = scope.parent.getFunctionParent();
-        if (parent.type === "Program" || parentScope.block.type === "Program" || parent.type === "CallExpression" && parent.callee === node) {
+        if (parent.type === 'Program' || parentScope.block.type === 'Program' || parent.type === 'CallExpression' && parent.callee === node) {
           return;
         }
-        if (node.type === "ArrowFunctionExpression") {
-          var _ret = (function () {
-            var isCompatible = true;
-            _this.traverse({
-              enter: function enter(node) {
-                if (node.type === "ThisExpression") {
-                  isCompatible = false;
-                  this.stop();
-                } else if (this.isFunction() && node.type !== "ArrowFunctionExpression") {
-                  this.skip();
-                }
+        if (node.type === 'ArrowFunctionExpression') {
+          var isCompatible = true;
+          this.traverse({
+            enter: function enter(node) {
+              if (node.type === 'ThisExpression') {
+                isCompatible = false;
+                this.stop();
+              } else if (this.isFunction() && node.type !== 'ArrowFunctionExpression') {
+                this.skip();
               }
-            });
-            if (!isCompatible) {
-              return {
-                v: undefined
-              };
             }
-          })();
-
-          if (typeof _ret === "object") return _ret.v;
+          });
+          if (!isCompatible) {
+            return;
+          }
         }
         var hoister = new PathHoister(this, this.parentPath.scope);
         hoister.run();
@@ -191,7 +183,7 @@ function build(babel) {
    * Normalize a function body so that it is always a BlockStatement.
    */
   function normalizeFunctionBody(node) {
-    if (node.type !== "BlockStatement") {
+    if (node.type !== 'BlockStatement') {
       return t.blockStatement([t.returnStatement(node)]);
     } else {
       return node;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-closure-elimination",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Removes closures from your JavaScript in the name of performance.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
   "devDependencies": {
     "mocha": "^2.2.4",
     "should": "^6.0.1",
-    "babel": "^5.0.0"
+    "babel": "^5.5.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -117,10 +117,10 @@ export default function build (babel: Object): Object {
       }
 
       if (node.type === 'FunctionDeclaration') {
-        let uid = this.path.parentPath.scope.generateUidBasedOnNode(node.id);
+        let uid = this.path.parentPath.scope.generateUidIdentifierBasedOnNode(node.id);
         this.path.parentPath.scope.rename(node.id.name, uid.name);
         path.insertBefore([node]);
-        this.path.remove();
+        this.path.dangerouslyRemove();
       }
       else {
         const uid = path.scope.generateUidIdentifier("ref");


### PR DESCRIPTION
Only two function calls changed :
1. `scope.generateUidBasedOnNode`  to `scope.generateUidIdentifierBasedOnNode`
2. `path.remove` to `path.dangerouslyRemove`