### PR TITLE
Issue 5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "babel-plugin-closure-elimination",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Removes closures from your JavaScript in the name of performance.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -152,13 +152,13 @@ export default function build (babel: Object): Object {
         enter(path) {
           const node = path.node;
           node[$classConstructor] = node.body[$classConstructor] = true;
-          path.traverse({
-            ClassMethod: {
-              enter({node}) {
-                node[$classMethod] = node.body[$classMethod] = true;
-              }
-            }
-          });
+          //path.traverse({// @todo maybe need skip methods?
+          //  ClassMethod: {
+          //    enter({node}) {
+          //      node[$classMethod] = node.body[$classMethod] = true;
+          //    }
+          //  }
+          //});
         }
       },
       Function: {
@@ -167,8 +167,7 @@ export default function build (babel: Object): Object {
             scope = path.scope,
             parent = path.parentPath.node,
             parentScope = scope.parent.getFunctionParent();
-          if (node[$classConstructor] || node.body[$classConstructor] ||
-            node[$classMethod] || node.body[$classMethod]) {
+          if (node[$classConstructor] || node.body[$classConstructor]) {
             return;
           }
           if (path.findParent(({node}) => node._generated || node._compact)) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,11 @@
 /**
  * # Closure Eliminator
  */
+
+// Do not use Symbol here. class constructor/body missed Symbol-props
+const $classConstructor = '__classConstructor';
+const $classMethod = '__classMethod';
+
 export default function build (babel: Object): Object {
   const {types: t, traverse} = babel;
 
@@ -143,12 +148,33 @@ export default function build (babel: Object): Object {
 
   return {
     visitor: {
+      Class: {
+        enter(path) {
+          const node = path.node;
+          node[$classConstructor] = node.body[$classConstructor] = true;
+          path.traverse({
+            ClassMethod: {
+              enter({node}) {
+                node[$classMethod] = node.body[$classMethod] = true;
+              }
+            }
+          });
+        }
+      },
       Function: {
         enter (path) {
           const node = path.node,
             scope = path.scope,
             parent = path.parentPath.node,
             parentScope = scope.parent.getFunctionParent();
+          if (node[$classConstructor] || node.body[$classConstructor] ||
+            node[$classMethod] || node.body[$classMethod]) {
+            return;
+          }
+          if (path.findParent(({node}) => node._generated || node._compact)) {
+            path.skip();
+            return;
+          }
           if (
             parent.type === 'Program' ||
             parentScope.block.type === 'Program' ||

--- a/test/fixtures/extended-class-from-known-class.js
+++ b/test/fixtures/extended-class-from-known-class.js
@@ -1,0 +1,22 @@
+class Base {
+  constructor() {
+    this.base = ()=>'base'
+  }
+}
+class Demo1 extends Base  {
+  foo () {
+    return [this.base(), "foo"];
+  }
+}
+class Demo2 extends Base  {
+  constructor() {
+    super();
+    this.bar = ()=>'bar';
+  }
+  foo () {
+    return [this.base(), this.bar()];
+  }
+}
+export default function demo() {
+  return [new Demo1().foo(), new Demo2().foo()];
+}

--- a/test/fixtures/extended-class-from-outer-parent.js
+++ b/test/fixtures/extended-class-from-outer-parent.js
@@ -1,0 +1,18 @@
+class Demo1 extends String  {
+  foo () {
+    var tmp = ()=>"foo";
+    return [tmp(), this.indexOf];
+  }
+}
+class Demo2 extends String  {
+  constructor() {
+    super();
+    this.bar = ()=>"bar";
+  }
+  foo () {
+    return [this.bar(), this.indexOf];
+  }
+}
+export default function demo() {
+  return [new Demo1().foo(), new Demo2().foo()];
+}

--- a/test/index.js
+++ b/test/index.js
@@ -103,7 +103,7 @@ describe('Closure Elimination', function () {
   eliminate("shadow-declaration", 2);
   eliminate("iife", 0);
   eliminate("class-compiled", 3);
-  eliminate("class-complex", 2);
+  eliminate("class-complex", 3);
   eliminate("extended-class-from-outer-parent", 2, [["foo", String.prototype.indexOf], ["bar", String.prototype.indexOf]]);
   eliminate("extended-class-from-known-class", 2, [["base", "foo"], ["base", "bar"]]);
 });

--- a/test/index.js
+++ b/test/index.js
@@ -16,8 +16,6 @@ function collectPositions (ast: Object): Object {
       if (path.isFunction()) {
         if(node.loc) {
           collected[JSON.stringify(node.loc)] = extractPath(path.scope);
-        } else {
-          throw new Error('Wrong transformed function. maybe wrong sourcemap?');
         }
       }
     }
@@ -42,26 +40,35 @@ function countHoisted (oldAst, newAst) {
   return total;
 }
 
-function runTest (basename, numberToRemove) {
+function runTest (basename, numberToRemove, expectedResult) {
   const source = load(basename);
-  const transformedNaked = transform(source, {plugins: ["transform-flow-strip-types"]});
+  const transformedNaked = transform(source, {"presets": ["es2015"],plugins: ["transform-flow-strip-types"]});
   //console.log(transformedNaked.code);
-  const transformedWithPlugin = transform(source, {plugins: [Plugin, "transform-flow-strip-types"]});
+  const transformedWithPlugin = transform(source, {"presets": ["es2015"],plugins: [Plugin, "transform-flow-strip-types"]});
   //console.log(transformedWithPlugin.code);
   const diff = countHoisted(transformedNaked.ast, transformedWithPlugin.ast);
   diff.should.equal(numberToRemove);
+  if (expectedResult) {
+    const context = {
+      exports: {}
+    };
+    const loaded = new Function('module', 'exports', transformedWithPlugin.code);
+    loaded(context, context.exports);
+    const result = typeof context.exports.default === 'function' ? context.exports.default() : context.exports.default;
+    result.should.eql(expectedResult);
+  }
 }
 
-function eliminate (basename, numberToRemove) {
+function eliminate (basename, numberToRemove, result) {
   it(`should eliminate ${numberToRemove} closure(s) from "${basename}"`, function () {
-    runTest(basename, numberToRemove);
+    runTest(basename, numberToRemove, result);
   });
 }
 
-eliminate.only = function (basename: string, numberToRemove: number) {
+eliminate.only = function (basename: string, numberToRemove: number, result) {
   it.only(`should eliminate ${numberToRemove} closure(s) from "${basename}"`, function () {
     try {
-      runTest(basename, numberToRemove);
+      runTest(basename, numberToRemove, result);
     }
     catch (e) {
       if (e.name !== 'AssertionError') {
@@ -97,5 +104,7 @@ describe('Closure Elimination', function () {
   eliminate("iife", 0);
   eliminate("class-compiled", 3);
   eliminate("class-complex", 2);
+  eliminate("extended-class-from-outer-parent", 2, [["foo", String.prototype.indexOf], ["bar", String.prototype.indexOf]]);
+  eliminate("extended-class-from-known-class", 2, [["base", "foo"], ["base", "bar"]]);
 });
 


### PR DESCRIPTION
try to fix https://github.com/codemix/babel-plugin-closure-elimination/issues/5

this branch blocks elimination in cases:
1. node, created by addHelper
Theirs in not movable by some reason
See https://phabricator.babeljs.io/T6802
2. Class constructor
when eliminated, renamed constructor, and outer name - synchronously
Yoy give export._App instead export.App - It's wrong