### PR TITLE
Don't transform class methods

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -154,13 +154,13 @@ export default function build (babel: Object): Object {
         enter(path) {
           const node = path.node;
           node[$classConstructor] = node.body[$classConstructor] = true;
-          //path.traverse({// @todo maybe need skip methods?
-          //  ClassMethod: {
-          //    enter({node}) {
-          //      node[$classMethod] = node.body[$classMethod] = true;
-          //    }
-          //  }
-          //});
+          path.traverse({
+            ClassMethod: {
+              enter({node}) {
+                node[$classMethod] = node.body[$classMethod] = true;
+              }
+            }
+          });
         }
       },
       Function: {
@@ -169,7 +169,7 @@ export default function build (babel: Object): Object {
             scope = path.scope,
             parent = path.parentPath.node,
             parentScope = scope.parent.getFunctionParent();
-          if (node[$classConstructor] || node.body[$classConstructor]) {
+          if (node[$classConstructor] || node.body[$classConstructor] || node[$classMethod]) {
             return;
           }
           if (path.findParent(({node}) => node._generated || node._compact)) {

--- a/test/fixtures/create-class.js
+++ b/test/fixtures/create-class.js
@@ -1,0 +1,14 @@
+function createClass() {
+  var C = class {
+    constructor(a, b) {
+      this.a = a;
+      this.b = b;
+    }
+
+    f() {
+      return () => 'yo';
+    }
+  };
+
+  return C;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -128,5 +128,6 @@ describe('Closure Elimination', function () {
   eliminate("extended-class-from-known-class", 2, [["base", "foo"], ["base", "bar"]]);
   eliminate("generator", 1, ["foo", 1, 2, 3]);
   eliminate("async", 1, true);
+  eliminate("create-class", 1);
 });
 


### PR DESCRIPTION
Related to #10.

```js
function createClass() {
  var C = class {
    constructor(a,b) {
      this.a = a;
      this.b = b;
    }

    f() {
      return () => 'yo';
    }
  };

  return C;
}
```
to
```js
'use strict';

var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();

function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }

function _ref2() {
  return 'yo';
}

function _ref() {
  return _ref2;
}

function createClass() {
  var C = function () {
    function C(a, b) {
      _classCallCheck(this, C);

      this.a = a;
      this.b = b;
    }

    _createClass(C, [{
      key: 'f',
      value: _ref
    }]);

    return C;
  }();

  return C;
}
```