### PR TITLE
Check AssignmentExpression parent of identifier bindings

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,7 @@ export default function build (babel: Object): Object {
         scope = path.scope;
       if (!path.isJSXIdentifier() && path.isIdentifier()) {
         // direct references that we need to track to hoist this to the highest scope we can
-        if (path.isReferenced()) {
+        if (path.isReferenced() || path.parent.type == 'AssignmentExpression') {
           const bindingInfo = scope.getBinding(node.name);
 
           // this binding isn't accessible from the parent scope so we can safely ignore it

--- a/test/fixtures/assign-expression.js
+++ b/test/fixtures/assign-expression.js
@@ -1,0 +1,20 @@
+function foo() {
+  var s = 1;
+
+  function bar() {
+    var s;
+    s = 3;
+
+    var func = () => {
+      s = 2;
+      return s;
+    };
+    var refFunc = () => "yo";
+    return [s, func(), refFunc(), s];
+  }
+  return bar().concat(s);
+}
+
+export default function demo() {
+  return foo();
+}

--- a/test/index.js
+++ b/test/index.js
@@ -130,5 +130,6 @@ describe('Closure Elimination', function () {
   eliminate("async", 1, true);
   //@todo better testing with babel-preset-es2015-node5 - look https://github.com/codemix/babel-plugin-closure-elimination/pull/11
   eliminate("create-class", 1);
+  eliminate("assign-expression", 3, [ 3, 2, "yo", 2, 1 ]);
 });
 


### PR DESCRIPTION
Related to https://github.com/codemix/babel-plugin-closure-elimination/issues/7#issuecomment-178809989, #9.

```js
function foo() {
  var s = 1;
  
  function bar() {
    var s;
    s = 1;

    const func = () => {
      s = 2;
    };
    const refFunc = () => 123;
    func();
    refFunc();
  }
  bar();
}
```

to
```js
'use strict';

function _ref() {
  return 'yo';
}

function _bar() {
  var s;
  s = 1;

  var func = function func() {
    s = 2;
  };
  var refFunc = _ref;
  func();
  refFunc();
}
function foo() {
  var s = 1;_bar();
}
```

And #9 output:

```js
'use strict';

Parser.prototype.data = function data() {
    var _this = this;

    function _ref(p) {
        return p.name === _this.currToken[1].slice(2, -2);
    }

    if (!this.currToken[1].indexOf('<\'')) {
        var requested = new Parser(_data.properties.filter(_ref)[0].syntax);
        this.root.nodes = this.root.nodes.concat(requested.nodes);
        this.last = this.root.nodes[this.root.nodes.length - 1];
    } else {
        (function () {
            var range = _this.currToken[1].slice(1, -1);
            var requested = _data.syntaxes.filter(function (s) {
                return s.name === range;
            })[0];
            if (requested) {
                _this.node = {
                    type: 'group',
                    nodes: new Parser(requested.syntax).nodes
                };
            } else {
                _this.node = {
                    type: 'data',
                    value: range,
                    exclusive: true
                };
            }
        })();
    }
    this.position++;
};
```

