### PR TITLE
Fix shorthand functions hoist

### DIFF
--- a/test/fixtures/object-shorthand-func.js
+++ b/test/fixtures/object-shorthand-func.js
@@ -1,0 +1,17 @@
+function shorthand() {
+  var obj = {
+    func1: () => 1,
+    func2() {
+      return 2;
+    },
+    func3() {
+      return 3;
+    }
+  }
+  return obj;
+}
+
+export default function demo() {
+  var { func1, func2, func3 } = shorthand();
+  return [func1(), func2(), func3()];
+}

--- a/test/index.js
+++ b/test/index.js
@@ -134,5 +134,6 @@ describe('Closure Elimination', function () {
   eliminate("assign-expression-and-referenced", 0, [ 1, [ 1, 1 ], [ 123 ] ]);
   //@todo maybe worked better, if used tip from https://github.com/codemix/babel-plugin-closure-elimination/issues/7#issuecomment-178859542
   eliminate("possible-scope-hoisting", 0/*TODO bar may be hoisted at 1 level*/, [1]);
+  eliminate("object-shorthand-func", 1, [1, 2, 3]);
 });
 


### PR DESCRIPTION
## The problem of Object shorthand functions

```js
function demo() {
  var obj = {
    func() {
      console.log('test');
    }
  };
}
```
will transform to:
```js
'use strict';

function _ref() {
  console.log('test');
}

function demo() {
  var obj = { _ref };
}
```

## Fixed

```js
'use strict';

function _ref() {
  console.log('test');
}

function demo() {
  var obj = {
    func: _ref
  };
}
```