### PR TITLE
Add path.ensureBlock for ArrowFunctionExpression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -196,6 +196,10 @@ export default function build (babel: Object): Object {
             return;
           }
           if (node.type === 'ArrowFunctionExpression') {
+            // If we don't use `transform-es2015-arrow-functions`,
+            // the non-block arrow function will not have own scope.
+            path.ensureBlock();
+
             let isCompatible = true;
             path.traverse({
               enter (subPath) {


### PR DESCRIPTION
If we don't use `transform-es2015-arrow-functions`, the non-block arrow function will not have own scope.

We can see [AST explorer](https://astexplorer.net/#/twEZquBZq5), it's just used `v1.0.5` code, no `preset-es2015` transforms, it's incorrect hoist for non-block arrow function.